### PR TITLE
Exporting default config for reference when customizing

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opendoor/react-calendar-timeline",
-  "version": "0.28.2",
+  "version": "0.28.3",
   "description": "Opendoor fork of https://www.npmjs.com/package/react-calendar-timeline",
   "main": "lib/index.js",
   "scripts": {

--- a/src/index.js
+++ b/src/index.js
@@ -10,4 +10,5 @@ export { default as TimelineHeaders } from './lib/headers/TimelineHeaders'
 export {default as SidebarHeader} from './lib/headers/SidebarHeader'
 export {default as CustomHeader} from './lib/headers/CustomHeader'
 export {default as DateHeader} from './lib/headers/DateHeader'
+export * from './lib/default-config';
 export default Timeline


### PR DESCRIPTION
**Overview of PR**

There exists the ability to customize the formatting of date headers. There's a big default config that one might not want to completely reimplement, but rather override parts of. This exports the default config so it can be referenced as a fallback for the parts a user might not want to override.

Tested this by building and importing from local (`file:///...`) in tessellation. The default configs were importable after the change.